### PR TITLE
Handle unexpected errrors

### DIFF
--- a/lib/chatbot/information_collector.ex
+++ b/lib/chatbot/information_collector.ex
@@ -57,6 +57,13 @@ defmodule Chatbot.InformationCollector do
     :poolboy.checkin(:collector, self())
   end
 
+  @impl GenServer
+  def terminate(_, state) do
+    stop_timeout_timer(state)
+    GenServer.cast(state.leader, {:worker_dead, self(), state.user, gettext("error_message")})
+    :poolboy.checkin(:collector, self())
+  end
+
   @impl true
   def handle_call({:initialize, ws}, _from, state) do
     Gettext.put_locale(ws.lang)
@@ -241,8 +248,8 @@ defmodule Chatbot.InformationCollector do
   @impl true
   def handle_cast(
         {:answer, %{"message" => msg, "update_id" => _}},
-        %{data: %{description: nil} = data} = state
-      ) do
+        %{data: %{gender: gen, ca: c,description: nil} = data} = state
+      ) when gen != nil and c != nil do
     keyboard = [
       [%{text: gettext("YES"), callback_data: "YES"}, %{text: gettext("NO"), callback_data: "NO"}]
     ]
@@ -256,6 +263,10 @@ defmodule Chatbot.InformationCollector do
 
     {:noreply, reset_timer(%{state | data: %{data | description: msg["text"]}})}
   end
+
+  # Ignore error prone messages
+  @impl true
+  def handle_cast({:answer, _}, state), do: {:noreply, state}
 
   ####################################################################
   ####################### PRIVATE FUNCTIONS ##########################

--- a/lib/chatbot/worker.ex
+++ b/lib/chatbot/worker.ex
@@ -77,14 +77,6 @@ defmodule Chatbot.Worker do
     do_handle_update(update, reset_timer(state))
   end
 
-  # Terminates the process when an error occured
-  @impl GenServer
-  def terminate(:shutdown, state) do
-    stop_timeout_timer(state)
-    GenServer.cast(state.leader, {:worker_dead, self(), state.user, gettext("error_message")})
-    :poolboy.checkin(:worker, self())
-  end
-
   # Terminates the process when no error occured
   @impl GenServer
   def terminate(:normal, state) do
@@ -107,6 +99,13 @@ defmodule Chatbot.Worker do
   @impl GenServer
   def terminate(:silence, state) do
     stop_timeout_timer(state)
+    :poolboy.checkin(:worker, self())
+  end
+
+  @impl GenServer
+  def terminate(_, state) do
+    stop_timeout_timer(state)
+    GenServer.cast(state.leader, {:worker_dead, self(), state.user, gettext("error_message")})
     :poolboy.checkin(:worker, self())
   end
 

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -976,7 +976,7 @@ msgstr ""
 #: lib/chatbot/information_collector.ex:69
 #, elixir-autogen, elixir-format
 msgid "Birth Location? (COUNTRY)"
-msgstr ""
+msgstr "¿Cuál es tu lugar de nacimiento?"
 
 #: lib/chatbot/graphs/urgent/work_graph.ex:61
 #: lib/chatbot/graphs/urgent/work_graph.ex:65
@@ -1152,7 +1152,7 @@ msgstr "Si has contactado con un anuncio de alquiler de vivienda y en algún mom
 #: lib/chatbot/information_collector.ex:181
 #, elixir-autogen, elixir-format
 msgid "How old are you?"
-msgstr ""
+msgstr "¿Cuantos años tienes?"
 
 #: lib/chatbot/information_collector.ex:302
 #, elixir-autogen, elixir-format
@@ -1473,7 +1473,7 @@ msgstr "----------------------------------------\n"
 "Hay diferentes vías para denunciar el acoso discriminatorio, por lo que *siempre te recomendamos que comiences por localizar una organización en tu zona que te pueda asesorar* sobre cuál es la mejor opción en tu caso concreto (enlaza recursos regionales).\n\n"
 "1. Si las denuncias internas no han funcionado, o si no confías en ellas, puedes denunciar ante la Inspección de Trabajo. Es un organismo público que se encarga de controlar el cumplimiento de las normativas relativas al empleo. Este organismo dispone de un [buzón online](https://oeitss.mites.gob.es/buzonitss) en el que se pueden comunicar las situaciones de acoso de forma anónima.\n\n"
 "2. Otra vía es la denuncia propiamente dicha en la Inspección de la Seguridad Social, que abre un proceso de control a la empresa. Para hacerla tendrás que aportar tus datos personales. Tu identidad estará protegida durante la investigación, pero podrás recibir información sobre cómo va el proceso. [Aquí](https://administracion.gob.es/pag_Home/Tu-espacio-europeo/derechos-obligaciones/empresas/empleados/seguridad-social/inspeccion.html#-ce27cd07198c) tienes más información sobre los mecanismos de denuncia.\n\n"
-"3. Las situaciones de acosos en las que hay indicios de discriminación xenófoba, racista o islamófoba pueden notificarse al [CEDRE](https://igualdadynodiscriminacion.igualdad.gob.es/home.do): llamada gratuita en el *021* y otras consultas en WhatsApp (628 860 507), [correo electrónico](mailto:consejo-sei@igualdad.gob.es), [formulario](https://igualdadynodiscriminacion.igualdad.gob.es/redOficinas/presentarQuejaConsulta.do) o acudir a una oficina ([consulta aquí la de tu Comunidad](https://igualdadynodiscriminacion.igualdad.gob.es/redOficinas/portada/home.html)).\n\n"
+"3. Las situaciones de acosos en las que hay indicios de discriminación xenófoba, racista o islamófoba pueden notificarse al [CEDRE](https://igualdadynodiscriminacion.igualdad.gob.es/home.do): llamada gratuita en el *021* y otras consultas en WhatsApp (628 860 507), [correo electrónico](mailto:consejo-sei@igualdad.gob.es), [formulario](https://igualdadynodiscriminacion.igualdad.gob.es/redOficinas/presentarQuejaConsulta.do) o acudir a una oficina ([consulta aquí la de tu Comunidad](https://igualdadynodiscriminacion.igualdad.gob.es/redOficinas/portada/home.htm)).\n\n"
 "4. También, en algunos casos, se puede realizar una denuncia judicial.\n\n"
 "Insistimos: hay varias vías de denuncia, y en una situación tan grave es importante que alguien te acompañe y te cuide."
 


### PR DESCRIPTION
All errors that may kill the worker of the information collector must trigger a notification to the leader to erase them from the list of active workers / ICs. 

I have also fixed the url from drive here.

Closes #24 